### PR TITLE
Refactor API endpoint data_org_structure to exclude inactive OrgUnits

### DIFF
--- a/oim_cms/api.py
+++ b/oim_cms/api.py
@@ -40,14 +40,15 @@ class OptionResource(DjangoResource):
         return getattr(self, 'data_' + self.request.GET['list'])()
 
     def data_org_structure(self):
+        # Return the current org structure, excluding inactive OrgUnits.
         return [recursive_node_to_dict(cache_tree_children(dept.get_descendants_active(include_self=True))[0])
-                for dept in OrgUnit.objects.filter(unit_type=0).order_by('name')]
+                for dept in OrgUnit.objects.filter(unit_type=0, active=True).order_by('name')]
 
     def data_cost_centre(self):
         return ['CC{} / {}'.format(*c) for c in CostCentre.objects.all().exclude(org_position__name__icontains='inactive').values_list('code', 'org_position__name')]
 
     def data_org_unit(self):
-        return [{'name': i.name, 'id': i.pk} for i in OrgUnit.objects.all()]
+        return [{'name': i.name, 'id': i.pk, 'active': i.active} for i in OrgUnit.objects.all()]
 
     def data_dept_user(self):
         return [u[0] for u in DepartmentUser.objects.filter(
@@ -175,6 +176,6 @@ api_urlpatterns = [
     url(r'^locations.csv', LocationResource.as_csv),
     url(r'^users/', include(DepartmentUserResource.urls())),
     url(r'^profile/', profile, name='api_profile'),
-    url(r'^options', include(OptionResource.urls())),
+    url(r'^options/', include(OptionResource.urls())),
     url(r'^whoami', WhoAmIResource.as_detail(), name='api_whoami'),
 ]

--- a/organisation/models.py
+++ b/organisation/models.py
@@ -478,11 +478,9 @@ class OrgUnit(MPTTModel):
 
     def get_descendants_active(self, *args, **kwargs):
         """Exclude 'inactive' OrgUnit objects from get_descendants() queryset.
-        Also exclude OrgUnit objects with 0 members.
         Returns a list of OrgUnits.
         """
         descendants = self.get_descendants(*args, **kwargs).exclude(active=False)
-        descendants = [o for o in descendants if o.members().count() > 0]
         return descendants
 
 


### PR DESCRIPTION
Refactor OrgUnit.get_descendants_active to NOT exclude units with no members.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/parksandwildlife/oim-cms/275)
<!-- Reviewable:end -->
